### PR TITLE
Change the header path of macOS to a more stable one

### DIFF
--- a/CommonCrypto/macosx.modulemap
+++ b/CommonCrypto/macosx.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }


### PR DESCRIPTION
After upgrading to Xcode 8, the SDK is updated to `MacOSX10.12.sdk`, so the old module map won't work.
But I notice it is just a symlink to a folder called `MacOSX.sdk` in the same folder.
I guess this path will not change in all upgrades of Xcode, but I'm not sure if this is something new in Xcode 8 all it is the same for Xcode 7. Since I only have Xcode 8 now, I can't confirm that.
But I think if this is also the case for Xcode 7 then we should change the path to `MacOSX.sdk` so we do not have to upgrade the framework to match every system upgrade.
