### PR TITLE
Uses DEVELOPER_DIR instead of hard-coded path to Xcode

### DIFF
--- a/CommonCrypto.xcodeproj/project.pbxproj
+++ b/CommonCrypto.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		21C0694C1C04358F00BD92CC /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.1.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
 		21C0694E1C04359500BD92CC /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS2.0.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
 		21FD8C7A1AE6B11A008DCDBA /* libcommonCrypto.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcommonCrypto.dylib; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/usr/lib/system/libcommonCrypto.dylib; sourceTree = DEVELOPER_DIR; };
+		69A3DDBE1E3AB218005561A3 /* ProcessModuleMap.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ProcessModuleMap.sh; sourceTree = "<group>"; };
 		80098A511C12E5890029C530 /* CommonCrypto.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CommonCrypto.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		80098A591C12E6370029C530 /* appletvos.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = appletvos.modulemap; sourceTree = "<group>"; };
 		80098A5A1C12E6880029C530 /* appletvsimulator.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = appletvsimulator.modulemap; sourceTree = "<group>"; };
@@ -84,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				211216861AE68D26004E1CE6 /* Info.plist */,
+				69A3DDBE1E3AB218005561A3 /* ProcessModuleMap.sh */,
 				2112169C1AE68D66004E1CE6 /* CommonCrypto.xcconfig */,
 				2112169D1AE68DD9004E1CE6 /* iphoneos.modulemap */,
 				2112169E1AE68DD9004E1CE6 /* iphonesimulator.modulemap */,

--- a/CommonCrypto.xcodeproj/xcshareddata/xcschemes/CommonCrypto-iOS.xcscheme
+++ b/CommonCrypto.xcodeproj/xcshareddata/xcschemes/CommonCrypto-iOS.xcscheme
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0800"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "&quot;$SRCROOT/CommonCrypto/ProcessModuleMap.sh&quot; &quot;$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/Modules/module.modulemap&quot; &gt; $TMPDIR/ProcessModuleMap.out 2&gt;&amp;1">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "216CAE331AE6B273009A69EF"
+                     BuildableName = "CommonCrypto.framework"
+                     BlueprintName = "CommonCrypto-iOS"
+                     ReferencedContainer = "container:CommonCrypto.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/CommonCrypto.xcodeproj/xcshareddata/xcschemes/CommonCrypto-macOS.xcscheme
+++ b/CommonCrypto.xcodeproj/xcshareddata/xcschemes/CommonCrypto-macOS.xcscheme
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0800"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "&quot;$SRCROOT/CommonCrypto/ProcessModuleMap.sh&quot; &quot;$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/Modules/module.modulemap&quot; &gt; $TMPDIR/ProcessModuleMap.out 2&gt;&amp;1">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "211216821AE68D26004E1CE6"
+                     BuildableName = "CommonCrypto.framework"
+                     BlueprintName = "CommonCrypto-macOS"
+                     ReferencedContainer = "container:CommonCrypto.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/CommonCrypto.xcodeproj/xcshareddata/xcschemes/CommonCrypto-tvOS.xcscheme
+++ b/CommonCrypto.xcodeproj/xcshareddata/xcschemes/CommonCrypto-tvOS.xcscheme
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0800"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "&quot;$SRCROOT/CommonCrypto/ProcessModuleMap.sh&quot; &quot;$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/Modules/module.modulemap&quot; &gt; $TMPDIR/ProcessModuleMap.out 2&gt;&amp;1">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "80098A501C12E5890029C530"
+                     BuildableName = "CommonCrypto.framework"
+                     BlueprintName = "CommonCrypto-tvOS"
+                     ReferencedContainer = "container:CommonCrypto.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/CommonCrypto.xcodeproj/xcshareddata/xcschemes/CommonCrypto-watchOS.xcscheme
+++ b/CommonCrypto.xcodeproj/xcshareddata/xcschemes/CommonCrypto-watchOS.xcscheme
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0800"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "&quot;$SRCROOT/CommonCrypto/ProcessModuleMap.sh&quot; &quot;$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/Modules/module.modulemap&quot; &gt; $TMPDIR/ProcessModuleMap.out 2&gt;&amp;1">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "804503271BA209F6002A5470"
+                     BuildableName = "CommonCrypto.framework"
+                     BlueprintName = "CommonCrypto-watchOS"
+                     ReferencedContainer = "container:CommonCrypto.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/CommonCrypto/ProcessModuleMap.sh
+++ b/CommonCrypto/ProcessModuleMap.sh
@@ -9,9 +9,9 @@
 # Replace DEVELOPER_DIR with the value of that environment variable in the given module map file
 echo "Replacing DEVELOPER_DIR in $1"
 echo "Before:\n---"
-cat $1
+cat "$1"
 echo "---"
-perl -pi -e "s{DEVELOPER_DIR}{$DEVELOPER_DIR}g" $1
+perl -pi -e "s{DEVELOPER_DIR}{$DEVELOPER_DIR}g" "$1"
 echo "\nAfter:\n---"
-cat $1
+cat "$1"
 echo "---"

--- a/CommonCrypto/ProcessModuleMap.sh
+++ b/CommonCrypto/ProcessModuleMap.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+#  ProcessModuleMaps.sh
+#  CommonCrypto
+#
+#  Created by Brian Hardy on 1/26/17.
+#  Copyright © 2017 Sam Soffes. All rights reserved.
+
+# Replace DEVELOPER_DIR with the value of that environment variable in the given module map file
+echo "Replacing DEVELOPER_DIR in $1"
+echo "Before:\n---"
+cat $1
+echo "---"
+perl -pi -e "s{DEVELOPER_DIR}{$DEVELOPER_DIR}g" $1
+echo "\nAfter:\n---"
+cat $1
+echo "---"

--- a/CommonCrypto/appletvos.modulemap
+++ b/CommonCrypto/appletvos.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "DEVELOPER_DIR/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/appletvsimulator.modulemap
+++ b/CommonCrypto/appletvsimulator.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "DEVELOPER_DIR/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/iphoneos.modulemap
+++ b/CommonCrypto/iphoneos.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "DEVELOPER_DIR/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/iphonesimulator.modulemap
+++ b/CommonCrypto/iphonesimulator.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "DEVELOPER_DIR/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/macosx.modulemap
+++ b/CommonCrypto/macosx.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/watchos.modulemap
+++ b/CommonCrypto/watchos.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "DEVELOPER_DIR/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/watchsimulator.modulemap
+++ b/CommonCrypto/watchsimulator.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "DEVELOPER_DIR/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }


### PR DESCRIPTION
Uses a shell script as a post-build action in the schemes to post-process the module maps.

This is a little bit of a hack, but it seems to work fine. What do you think, @soffes ?

The goal is to make this work regardless of where Xcode is installed.